### PR TITLE
minor client improvements

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import click
 from typing import Optional
 from client_state import ClientState
@@ -7,7 +9,7 @@ IS_LIVE = False
 
 
 @click.group()
-@click.option('--nameserver', type=str, default='127.0.0.1', show_default=True, help="IP-Address of the nameserver.")
+@click.option('--nameserver', type=str, default=None, help="IP-Address of the nameserver.")
 @click.option('--domain', type=str, default='evil.bot', show_default=True, help="Domain name of the target server.")
 @click.option('--lag', type=click.IntRange(min=0), default=0, help="Number of seconds between chained requests.")
 @click.option('--id', 'client_id', type=int, help="Set the id of the client (otherwise a new id gets requested for every command).")
@@ -67,7 +69,7 @@ def data(comm: Communicator, head: str, body: str):
 
 
 @main.command()
-@click.option('--webpage', type=str, required=True, help="The requested webpage.")
+@click.argument('webpage', type=str)
 @click.pass_obj
 def curl(comm: Communicator, webpage: str):
     """
@@ -79,7 +81,7 @@ def curl(comm: Communicator, webpage: str):
 
 
 @main.command()
-@click.option('--command', type=str, required=True, help="The shell command that should be executed.")
+@click.argument('command', type=str)
 @click.pass_obj
 def shell(comm: Communicator, command: str):
     """

--- a/client/communicator.py
+++ b/client/communicator.py
@@ -17,7 +17,8 @@ class Communicator:
 
     def __init__(self, client_state: ClientState, domain: str, name_server: str, client_id: Optional[int] = None,
                  request_lag_seconds: int = 1, live_output: bool = False):
-        self._name_server = name_server
+        # if no name-server is provided, get the first name-server configured by the system
+        self._name_server = dns.resolver.get_default_resolver().nameservers[0] if name_server is None else name_server
         self._response_handler = ClientStateResponseHandler(client_state)
         self._request_handler = ClientStateRequestHandler(client_state, domain)
         self._state_reader = ClientStateReader(client_state)


### PR DESCRIPTION
- convert command options for curl and shell to arguments.
- get default nameserver from resolv.conf
- add python shebang
- make client.py executable (chmod u+x)

In practice this means:
- BEFORE: `python client.py --nameserver $DNS_SERVER_IP --id 1 curl --webpage https://google.com`
- AFTER: `./client.py --id 1 curl https://google.com`

Enjoy :)